### PR TITLE
Removes reCAPTCHA checking for the plugin endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@conversationai/perspectiveapi-simple-server",
   "description": "A simple server for use with the Perspective API. Serves static content and provides an open endpoint to send requests for one attribute to, e.g. toxicity. This should illustrate how to send requests to the API.",
   "repository": "https://github.com/conversationai/perspectiveapi-simple-server",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "Apache-2.0",
   "scripts": {
     "setup": "mkdir -p build/server/ && mkdir -p build/config/ && rsync --ignore-existing server_config.template.json build/config/server_config.json",

--- a/src/serving.ts
+++ b/src/serving.ts
@@ -113,7 +113,7 @@ export class Server {
 
     // Define an endpoint with CORS enabled to be used by the plugin.
     this.app.options('/plugin/check', cors()) // enable CORS for pre-flight requests.
-    this.app.post('/plugin/check', cors(), this.verifyRecaptcha(), (req, res) => {
+    this.app.post('/plugin/check', cors(), (req, res) => {
       this.log.write('Received a cross-original check request.');
       this.sendAnalyzeRequest(this.getAnalyzeCommentRequest(req))
         .then((response: AnalyzeCommentResponse) => {


### PR DESCRIPTION
Since we don't know what website the plugin will be hosted on, we can't whitelist it, which means reCAPTCHA checking will always fail. 